### PR TITLE
Fix dynamic heights

### DIFF
--- a/lib/Agate.tsx
+++ b/lib/Agate.tsx
@@ -54,7 +54,7 @@ function App(props: AgateProps) {
   
   
     return (
-      <Stack gap={2} className="Agate">
+      <Stack gap={2} className="Agate h-100">
       <Header
         {...props}
         projectName={project}
@@ -90,4 +90,3 @@ function App(props: AgateProps) {
   }
   
   export default Agate;
-  

--- a/lib/components/Data.tsx
+++ b/lib/components/Data.tsx
@@ -30,7 +30,7 @@ export function Data(props: DataProps) {
     };
   
     return (
-      <Container fluid className="g-2">
+      <Container fluid className="g-2 d-flex h-100">
         <Stack gap={2}>
           <Results
             {...props}

--- a/lib/components/Results.tsx
+++ b/lib/components/Results.tsx
@@ -22,7 +22,6 @@ export function Results(props: ResultsProps) {
       });
 
     return (
-      // We set the height of the card to be the view port width minus a little bit (worked out empirically) for the navbar
       <Card className="flex-grow-1">
         <Card.Header>
           <Card.Title>Ingestion

--- a/lib/components/Results.tsx
+++ b/lib/components/Results.tsx
@@ -23,7 +23,7 @@ export function Results(props: ResultsProps) {
 
     return (
       // We set the height of the card to be the view port width minus a little bit (worked out empirically) for the navbar
-      <Card style={{ height: "calc(100vh - 4.5em)" }}>
+      <Card className="flex-grow-1">
         <Card.Header>
           <Card.Title>Ingestion
           <Button

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,8 @@ import "./font.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <Agate httpPathHandler={httpPathHandler} extVersion="Mock" />
+    <div style={{ height: "100vh" }}>
+      <Agate httpPathHandler={httpPathHandler} extVersion="Mock" />
+    </div>
   </React.StrictMode>
 );


### PR DESCRIPTION
Far more trial and error went into this than I'd have liked, but I think that this combination of classes results in things sitting nicely in the window even as we resize it. Note this also involved getting the Agate Jupyter extension up and running (basically a copy of the Onyx one), which will be coming soon.

<img width="1186" height="839" alt="image" src="https://github.com/user-attachments/assets/962ce10c-3c83-46ad-9349-fef7ecc65ecc" />

<img width="2164" height="2160" alt="image" src="https://github.com/user-attachments/assets/37f7dab4-8ddd-4501-9cb0-4a2f130524a3" />
