### PR TITLE
Release fixes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,15 +11,8 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          registry-url: "https://registry.npmjs.org"
-
-      - name: Install npm 11.5
-        run: npm install -g npm@11.5
-
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v6
       - name: Display node and npm versions
         run: |
           node -v

--- a/LICENCE
+++ b/LICENCE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 CLIMB-TRE
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "climb-agate-gui",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "climb-agate-gui",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@tanstack/react-query": "^4.36.1",
         "ag-grid-community": "^34.1.2",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
       "email": "n.a.butcher@bham.ac.uk"
     },
     {
+      "name": "Thomas Brier",
+      "email": "t.o.brier@bham.ac.uk"
+    },
+    {
       "name": "Tom Neep",
       "email": "t.j.neep@bham.ac.uk"
     }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "bugs": {
     "url": "https://github.com/CLIMB-TRE/agate-gui/issues"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/CLIMB-TRE/agate-gui"
+  },
   "contributors": [
     {
       "name": "Neil Butcher",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,20 @@
 {
   "name": "climb-agate-gui",
-  "version": "0.2.0",
+  "version": "0.2.1",
+  "homepage": "https://github.com/CLIMB-TRE/agate-gui",
+  "bugs": {
+    "url": "https://github.com/CLIMB-TRE/agate-gui/issues"
+  },
+  "contributors": [
+    {
+      "name": "Neil Butcher",
+      "email": "n.a.butcher@bham.ac.uk"
+    },
+    {
+      "name": "Tom Neep",
+      "email": "t.j.neep@bham.ac.uk"
+    }
+  ],
   "type": "module",
   "main": "dist/main.js",
   "types": "dist/main.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "climb-agate-gui",
   "version": "0.2.1",
+  "license": "MIT",
   "homepage": "https://github.com/CLIMB-TRE/agate-gui",
   "bugs": {
     "url": "https://github.com/CLIMB-TRE/agate-gui/issues"


### PR DESCRIPTION
This PR fixes issues I found when trying to auto publish a release to `npm`.

+ Update actions to use later versions
+ Add homepage, bugs, and contributors sections
+ Bump version to 0.2.1

+ [x] Still need to add a LICENCE